### PR TITLE
Correction de celà

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Voici les quelques règles à respecter afin de que nous puissions traiter au pl
 
 * Vérifiez que votre problème n'a pas déjà été signalé 
 * Essayez de reproduire plusieurs fois votre problème avant d'entreprendre un rapport
-* Indiquez, si possible, les étapes pour reproduire le problème, celà nous permetra de le résourde plus rapidement
+* Indiquez, si possible, les étapes pour reproduire le problème, cela nous permetra de le résourde plus rapidement
 * Lors de la création de votre ticket, n'oubliez de mentionner votre environnement (http://supportdetails.net/ pour générer un rapport automatisé)
 * Si votre problème concerne votre abonnement ou son renouvellement, merci de passer par l'interface de support utilisateur (http://www.nextinpact.com/a-propos.htm#nouscontacter_section)
 


### PR DESCRIPTION
Bien qu’attestée dans la littérature, cette variante n’est pas conforme à l’étymologie ni aux règles de grammaire du français.
https://fr.wiktionary.org/wiki/cel%C3%A0